### PR TITLE
Support HTTP Trigger Response

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     description="WayScript gives you flexible building blocks to seamlessly integrate, automate and host tools in the cloud.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=['requests>=2.22.0'],
+    install_requires=['slack-sdk', 'requests>=2.22.0'],
     url="https://github.com/wayscript/wayscript-python",
     package_dir={'': 'src'},
     packages=["wayscript"],

--- a/src/wayscript/context.py
+++ b/src/wayscript/context.py
@@ -6,9 +6,9 @@ from . import utils
 @lru_cache()
 def _get_process_detail_expanded_data() -> dict:
     """Wrapper to cache data from process_detail_expanded call"""
-    process_uuid = utils.get_process_uuid()
+    process_id = utils.get_process_id()
     client = utils.WayScriptClient()
-    response = client.get_process_detail_expanded(process_uuid)
+    response = client.get_process_detail_expanded(process_id)
     response.raise_for_status()
     return response.json()
 

--- a/src/wayscript/settings.py
+++ b/src/wayscript/settings.py
@@ -6,13 +6,16 @@ import os
 
 PROCESSES_ROUTE = "processes"
 LAIRS_ROUTE = "lairs"
+WEBHOOKS = "webhooks"
 WORKSPACES_ROUTE = "workspaces"
 WORKSPACE_INTEGRATIONS_ROUTE = "workspace-integrations"
+
 
 
 ROUTES = {
     "lairs": {"detail": f"{LAIRS_ROUTE}/$id"},
     "processes": { "detail_expanded": f"{PROCESSES_ROUTE}/$id/detail"},
+    "webhooks": {"http_trigger_response": f"{WEBHOOKS}/http-trigger/response/$id"},
     "workspaces": {"detail": f"{WORKSPACES_ROUTE}/$id"},
     "workspace-integrations": {"detail": f"{WORKSPACE_INTEGRATIONS_ROUTE}/$id"}
 }

--- a/src/wayscript/triggers/http_trigger.py
+++ b/src/wayscript/triggers/http_trigger.py
@@ -1,0 +1,19 @@
+from wayscript import utils
+
+
+def send_response(data: dict=None, headers: dict=None, status_code: int=None):
+    """Send response to http trigger endpoint"""
+    assert data, "data kwarg is required"
+    assert headers, "headers kwarg is required"
+    assert status_code, "status_code kwarg is required"
+    wayscript_client = utils.WayScriptClient()
+    process_id = utils.get_process_id()
+    payload = {
+        "data": data,
+        "headers": headers,
+        "status_code": status_code,
+    }
+    response = wayscript_client.post_webhook_http_trigger_response(process_id, payload)
+    response.raise_for_status()
+
+    return response

--- a/src/wayscript/utils.py
+++ b/src/wayscript/utils.py
@@ -58,3 +58,14 @@ class WayScriptClient:
         url = self._get_url(subpath="workspaces", route="detail", template_args={"id": _id})
         response = self.session.get(url)
         return response
+
+    def post_webhook_http_trigger_response(self, _id: str, payload: dict=None):
+        """
+        Post an http trigger response
+
+        _id: process id launched by http trigger
+        payload: a payload describing how to respond to the http trigger's request
+        """
+        url = self._get_url(subpath="webhooks", route="http_trigger_response", template_args={"id": _id})
+        response = self.session.post(url, json=payload)
+        return response

--- a/src/wayscript/utils.py
+++ b/src/wayscript/utils.py
@@ -8,14 +8,14 @@ from . import settings
 
 def get_process_execution_user_token():
     """Return the auth token of the user this process is executing on behalf of"""
-    token = os.environ["WAYSCRIPT_EXECUTION_USER_TOKEN"]
+    token = os.environ.get("WAYSCRIPT_EXECUTION_USER_TOKEN")
     return token
 
 
-def get_process_uuid():
+def get_process_id():
     """Return uuid of current container execution"""
-    process_uuid = os.environ["WAYSCRIPT_PROCESS_UUID"]
-    return process_uuid
+    process_id = os.environ["WS_PROCESS_ID"]
+    return process_id
 
 
 class WayScriptClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def stub_environment():
     
     stubbed_environment_variables = [
         "WAYSCRIPT_EXECUTION_USER_TOKEN",
-        "WAYSCRIPT_PROCESS_UUID",
+        "WS_PROCESS_ID",
     ]
 
     for var in stubbed_environment_variables:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,19 +5,21 @@ from wayscript import settings, utils
 
 @responses.activate
 @pytest.mark.parametrize(
-    "method,_id,expected_subpath",
+    "method,_id,expected_subpath,http_method",
     [
-        ("get_workspace_detail", "19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0", "workspaces/19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0"),
-        ("get_lair_detail","334d88dc-f9bf-4d3e-a7a2-0dec1279e4d9", "lairs/334d88dc-f9bf-4d3e-a7a2-0dec1279e4d9"),
-        ("get_process_detail_expanded","378daaa4-0fc3-48da-9f51-f745151dfc08", "processes/378daaa4-0fc3-48da-9f51-f745151dfc08/detail"),
-        ("get_workspace_integration_detail","9b3e827e-f113-41fc-a14e-4ba53afa1707", "workspace-integrations/9b3e827e-f113-41fc-a14e-4ba53afa1707"),
+        ("get_lair_detail","334d88dc-f9bf-4d3e-a7a2-0dec1279e4d9", "lairs/334d88dc-f9bf-4d3e-a7a2-0dec1279e4d9", "GET"),
+        ("get_process_detail_expanded","378daaa4-0fc3-48da-9f51-f745151dfc08", "processes/378daaa4-0fc3-48da-9f51-f745151dfc08/detail", "GET"),
+        ("post_webhook_http_trigger_response", "19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0", "webhooks/http-trigger/response/19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0", "POST"),
+        ("get_workspace_detail", "19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0", "workspaces/19cb0a0f-f48c-4191-84b5-ba7be8ceb1a0", "GET"),
+        ("get_workspace_integration_detail","9b3e827e-f113-41fc-a14e-4ba53afa1707", "workspace-integrations/9b3e827e-f113-41fc-a14e-4ba53afa1707", "GET"),
     ],
 )
-def test__get_url_generates_correct_endpoints(method, _id, expected_subpath):
+def test__get_url_generates_correct_endpoints(method, _id, expected_subpath, http_method):
     """Test that wayscript client's _get_url method generates the correct expected url subpath"""
     
     expected_url = f"{settings.WAYSCRIPT_ORIGIN}/{expected_subpath}"
-    responses.add(responses.GET, expected_url,
+    responses_method = getattr(responses, http_method)
+    responses.add(responses_method, expected_url,
                   json={}, status=200)
 
     client = utils.WayScriptClient()

--- a/tests/triggers/test_http_trigger.py
+++ b/tests/triggers/test_http_trigger.py
@@ -1,0 +1,16 @@
+import responses
+from wayscript.triggers import http_trigger
+
+
+@responses.activate
+def test_send_response(patch_client_get_url):
+    """Test sending response via http trigger"""
+    expected_response = {"message": "ok"}
+    responses.add(
+        responses.POST, patch_client_get_url, json=expected_response, status=200
+    )
+    headers = {"content-type": "application"}
+    data = {"hello": "world"}
+    response = http_trigger.send_response(data=data, headers=headers, status_code=200)
+
+    assert expected_response == response.json()


### PR DESCRIPTION
## Change description

Support HTTP Trigger Response.

Still need a way of grabbing the process id while executing inside a lair.

## Checklist

- [x] Application changes have been tested and automated tests have been added, if applicable
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

## Related issues

> Fixes #xxxx