### PR TITLE
Cut 0.2.0

### DIFF
--- a/files/usr/local/bin/publish.sh
+++ b/files/usr/local/bin/publish.sh
@@ -16,4 +16,5 @@ sed -i "s/$VERSION_PLACEHOLDER/version='$VERSION',/" $PROJECT_DIR/setup.py
 
 DIST_DIR=$PROJECT_DIR/dist
 python setup.py sdist --dist-dir $DIST_DIR
-twine upload dist/wayscript-$VERSION.tar.gz
+
+twine upload ./dist/wayscript-$VERSION.tar.gz

--- a/files/usr/local/bin/publish.sh
+++ b/files/usr/local/bin/publish.sh
@@ -16,4 +16,4 @@ sed -i "s/$VERSION_PLACEHOLDER/version='$VERSION',/" $PROJECT_DIR/setup.py
 
 DIST_DIR=$PROJECT_DIR/dist
 python setup.py sdist --dist-dir $DIST_DIR
-twine upload dist/wayscript-legacy-$VERSION.tar.gz
+twine upload dist/wayscript-$VERSION.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     install_requires=['slack-sdk', 'requests>=2.22.0'],
     url="https://github.com/wayscript/wayscript-python",
     package_dir={'': 'src'},
-    packages=["wayscript"],
+    packages=setuptools.find_packages(where="src"),
     license='MIT',
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Change description

A few tweaks before publishing.

Tested by publishing to test pypy under `wayscript-0.2.0rc2` and successfully installing into a lair. 😄

https://test.pypi.org/project/wayscript/#history

I wanted to get something out for us to test on, but I am now wondering if perhaps we need some documentation to indicate to users of versions `<=0.1.1`. How aggressive are we comfortable being?

if you just want to test the package, you can do so with a `requirements.txt` file in a lair root that looks like this:
```
--pre
-i https://test.pypi.org/simple/
wayscript==0.2.0rc2
```

## Checklist

- [x] Application changes have been tested and automated tests have been added, if applicable
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

## Related issues

> Fixes #xxxx
