### PR TITLE
Support User Lookup by Application Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ from wayscript import context
 event = context.get_event()
 ```
 
+### Checking user by application key
+```
+from wayscript import context, utils
+
+application_key = utils.get_application_key()
+user = context.get_user_by_application_key(application_key)
+```
 ## Triggers
 
 ### HTTP Triggers

--- a/src/wayscript/context.py
+++ b/src/wayscript/context.py
@@ -53,3 +53,14 @@ def get_workspace():
     response.raise_for_status()
     data = response.json()
     return data
+
+
+def get_user_by_application_key(application_key: str) -> dict:
+    """Return a user object for the given application key"""
+    lair_data = get_lair()
+    workspace_id = lair_data["workspace_id"]
+    client = utils.WayScriptClient()
+    response = client.get_user_detail_by_application_key(application_key, workspace_id)
+    response.raise_for_status()
+    data = response.json()
+    return data

--- a/src/wayscript/context.py
+++ b/src/wayscript/context.py
@@ -47,7 +47,7 @@ def get_lair():
 def get_workspace():
     """Return workspace metadata"""
     lair_data = get_lair()
-    workspace_id = lair_data["workspace_uuid"]
+    workspace_id = lair_data["workspace_id"]
     client = utils.WayScriptClient()
     response = client.get_workspace_detail(workspace_id)
     response.raise_for_status()

--- a/src/wayscript/settings.py
+++ b/src/wayscript/settings.py
@@ -17,8 +17,11 @@ ROUTES = {
     "lairs": {"detail": f"{LAIRS_ROUTE}/$id"},
     "processes": { "detail_expanded": f"{PROCESSES_ROUTE}/$id/detail"},
     "webhooks": {"http_trigger_response": f"{WEBHOOKS}/http-trigger/response/$id"},
-    "workspaces": {"detail": f"{WORKSPACES_ROUTE}/$id"},
-    "workspace-integrations": {"detail": f"{WORKSPACE_INTEGRATIONS_ROUTE}/$id"}
+    "workspaces": {
+        "detail": f"{WORKSPACES_ROUTE}/$id",
+        "user_application_key_detail": f"{WORKSPACES_ROUTE}/$id/users/self",
+        },
+    "workspace-integrations": {"detail": f"{WORKSPACE_INTEGRATIONS_ROUTE}/$id"},
 }
 
 # origin is scheme + domain + port. explanation: https://stackoverflow.com/a/37366696/4293004

--- a/src/wayscript/utils.py
+++ b/src/wayscript/utils.py
@@ -120,5 +120,5 @@ class WayScriptClient:
         Request user detail using its application key
         """
         url = self._get_url(subpath="workspaces", route="user_application_key_detail", template_args={"id": workspace_id})
-        response = self.session.get(url, headers={"authorization": application_key})
+        response = self.session.get(url, headers={"authorization": f"Bearer {application_key}"})
         return response

--- a/src/wayscript/utils.py
+++ b/src/wayscript/utils.py
@@ -26,6 +26,10 @@ def get_refresh_token():
     refresh_token = os.environ["WAYSCRIPT_EXECUTION_USER_REFRESH_TOKEN"]
     return refresh_token
 
+def get_application_key():
+    application_key = os.environ["WAYSCRIPT_EXECUTION_USER_APPLICATION_KEY"]
+    return application_key
+
 
 def retry_on_401_wrapper(f):
 
@@ -109,4 +113,12 @@ class WayScriptClient:
         """
         url = self._get_url(subpath="webhooks", route="http_trigger_response", template_args={"id": _id})
         response = self.session.post(url, json=payload)
+        return response
+
+    def get_user_detail_by_application_key(self, application_key: str, workspace_id: str):
+        """
+        Request user detail using its application key
+        """
+        url = self._get_url(subpath="workspaces", route="user_application_key_detail", template_args={"id": workspace_id})
+        response = self.session.get(url, headers={"authorization": application_key})
         return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,20 @@ def lairs_detail_response():
 
 
 @pytest.fixture
+def user_detail_response():
+    """Data representing a response from GET /workspaces/<id>/users/self"""
+    data = {
+        "avatar": "https://lh3.googleusercontent.com/a-/BOh14LjZkR7iuACWXfkCrZX3nixJCdRUc_3PYP9wu7CA=s96-c",
+        "created_date": "2021-12-15T03:18:23.865839",
+        "email": "foobar@fooey.com",
+        "first_name": "John",
+        "id": "705c088f-1211-4c0e-a520-1d5f76b6940e",
+        "last_name": "Jingleheimerschmidt"
+    }
+    return data
+
+
+@pytest.fixture
 def workspaces_detail_response():
     """Data from GET /workspaces/<id>"""
     data = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,16 +64,16 @@ def processes_detail_expanded_response():
 
 @pytest.fixture
 def lairs_detail_response():
-    """Data representing a response from `GET /lairs/<lair_uuid>`"""
+    """Data representing a response from `GET /lairs/<id>`"""
     data = {
         "created_date": "Thu, 22 Jul 2021 15:40:23 GMT",
         "file_object": "",
         "internal_id": "122",
         "lair_manager": "0faa1b77-0e54-4d50-83d4-412a972bc99b",
         "lair_name": "a6ed446a-2cb6-4421-98f5-3352020f2db8",
-        "lair_uuid": LAIR_ID,
+        "id": LAIR_ID,
         "last_run_date": "Thu, 22 Jul 2021 15:40:23 GMT",
-        "workspace_uuid": WORKSPACE_ID,
+        "workspace_id": WORKSPACE_ID,
     }
 
     return data
@@ -85,7 +85,7 @@ def workspaces_detail_response():
     data = {
         "file_object": "",
         "workspace_name": "fbb01af8-c476-4928-8921-b12e9ba91436",
-        "workspace_uuid": WORKSPACE_ID,
+        "workspace_id": WORKSPACE_ID,
     }
     return data
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -36,3 +36,12 @@ def test_get_workspace(patch_client_get_url, lairs_detail_response, workspaces_d
 
     workspace = ws_context.get_workspace()
     assert workspace == workspaces_detail_response
+
+@responses.activate
+def test_get_user_by_application_key(patch_client_get_url, lairs_detail_response, user_detail_response, monkeypatch):
+    responses.add(responses.GET, patch_client_get_url,
+                  json=user_detail_response, status=200)
+
+    monkeypatch.setattr(ws_context, "get_lair", lambda *args, **kwargs: lairs_detail_response)
+
+    assert ws_context.get_user_by_application_key("my-application-key") == user_detail_response


### PR DESCRIPTION
## Change description

Support looking up user detail via application key.

Tested with http trigger lair:

```
# my-lair-a > api.py

import os
from wayscript.triggers import http_trigger

from wayscript import context, utils

application_key = utils.get_application_key()
user = context.get_user_by_application_key(application_key)

payload = {"hello": "world", "key": os.environ.get("WAYSCRIPT_EXECUTION_USER_APPLICATION_KEY"), "user": user}
headers = {"content-type": "application/json"}
status_code = 200

http_trigger.send_response(data=payload, headers=headers, status_code=status_code)
```

## Checklist

- [x] Application changes have been tested and automated tests have been added, if applicable
- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

## Related issues

> Fixes #xxxx